### PR TITLE
Clarification on the Notes section needed! Please see detailed commit message

### DIFF
--- a/episodes/03-dates-as-data.md
+++ b/episodes/03-dates-as-data.md
@@ -150,18 +150,6 @@ part) of the cell that is being operated upon, (unless you did some sort of
 formatting to the cell before, and then all bets are off). Month and year
 rollovers are internally tracked and applied.
 
-**Note**
-Adding years and months and days is slightly trickier because we need to make
-sure that we are adding the amount to the correct entity.
-
-- First we extract the single entities (day, month or year)
-- We can then add values to do that
-- Finally the complete date string is reconstructed using the `DATE()` function.
-
-As for dates, times are handled in a similar way; seconds can be directly
-added but to add hour and minutes we need to make sure that we are adding
-the quantities to the correct entities.
-
 Which brings us to the many different ways Excel provides in how it displays dates. If you refer to the figure above, you'll see that
 there are many ways that ambiguity creeps into your data depending on the format you chose when you enter your data, and if you're not
 fully aware of which format you're using, you can end up actually entering your data in a way that Excel will badly misinterpret and


### PR DESCRIPTION
"we can easily add days, months or years to a given date." https://github.com/fishtree-attempt/spreadsheet-ecology-lesson/blob/main/episodes/03-dates-as-data.md?plain=1#L133

then just a few lines below it reads: 

"Adding years and months and days is slightly trickier because we need to make sure that we are adding the amount to the correct entity."


- First we extract the single entities (day, month or year)
- We can then add values to do that
- Finally the complete date string is reconstructed using the `DATE()` function." https://github.com/fishtree-attempt/spreadsheet-ecology-lesson/blob/main/episodes/03-dates-as-data.md?plain=1#L154-L159


So: Firstly it is stated that adding days/months/years to a given date is easy while the same task ("Adding years and months and days") is deemed "slightly trickier".

The first bullet asks to extract the single entities. I am not sure what this whole note is about. I feel that adding years to another date might be consdiered "tricky"? Why is that?

The second bullet is very unspecific. What is "that"?

The third bullet talks about a reconstruction.

What is the main challenge?
Was the date not formatted correctly in the first instance and that's why adding days, etc. is complicated? This whole 'Note' confuses me.
We should add an example that clearly distinguishes the easy approach (#L133) from the (#L154) 'trickier' version. 

If others do not see the point (I don't), we could also consider deleting this whole note?